### PR TITLE
data/appdata.xml: Make validation successful

### DIFF
--- a/data/com.georgefb.haruna.appdata.xml
+++ b/data/com.georgefb.haruna.appdata.xml
@@ -1,10 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  SPDX-FileCopyrightText: 2020 George Florea Bănuș <georgefb899@gmail.com>
 
  SPDX-License-Identifier: CC-BY-4.0
  -->
-
-<?xml version="1.0" encoding="utf-8"?>
 <component type="desktop-application">
     <name>Haruna Video Player</name>
     <id>com.georgefb.haruna</id>


### PR DESCRIPTION
Previously appstram validation would fail on current AppData XML file:

```
% appstreamcli validate data/com.georgefb.haruna.appdata.xml
E: ~:~: xml-markup-invalid Could not parse XML data: Entity: line 7: parser error : XML declaration allowed only at the start of the document
<?xml version="1.0" encoding="utf-8"?>
     ^


Validation failed: errors: 1
```



With this comment, the appstream validation would be successful:

```
% appstreamcli validate data/com.georgefb.haruna.appdata.xml
I: com.georgefb.haruna:16: summary-has-dot-suffix A Qt/QML video player built on top of libmpv.
I: com.georgefb.haruna:19: description-first-para-too-short A Qt/QML video player built on top of libmpv.

Validation was successful: infos: 2
```