### PR TITLE
Fix theming on AppImage

### DIFF
--- a/appimage-amd64.yaml
+++ b/appimage-amd64.yaml
@@ -56,6 +56,8 @@ AppDir:
       - libqt5widgets5
       - libkf5i18n5
       - python3
+      - breeze 
+      - qml-module-org-kde-qqc2desktopstyle
  
     exclude:
       - libkf5service-bin


### PR DESCRIPTION
Fix theming on AppImage by including breeze and qml-module-org-kde-qqc2desktopstyle

Increases size by around 45 MB but worth it for someone who discovered haruna recently and want to try it.

![image](https://user-images.githubusercontent.com/66936172/112055240-9b248700-8b7c-11eb-873e-df110a72e6f1.png)