### PR TITLE
Fix theming on AppImage

### DIFF
--- a/appimage-amd64.yaml
+++ b/appimage-amd64.yaml
@@ -56,7 +56,8 @@ AppDir:
       - libqt5widgets5
       - libkf5i18n5
       - python3
-      - breeze 
+      - breeze
+      - breeze-icon-theme 
       - qml-module-org-kde-qqc2desktopstyle
  
     exclude:

--- a/appimage-amd64.yaml
+++ b/appimage-amd64.yaml
@@ -56,6 +56,8 @@ AppDir:
       - libqt5widgets5
       - libkf5i18n5
       - python3
+      - breeze 
+      - qml-module-org-kde-qqc2desktopstyle
  
     exclude:
       - libkf5service-bin


### PR DESCRIPTION
Fix theming on AppImage by including breeze and qml-module-org-kde-qqc2desktopstyle

Increases size by around 45 MB but worth it for someone who discovered haruna recently and want to try it.

![image](https://user-images.githubusercontent.com/66936172/112093143-ec556a80-8bbe-11eb-991b-1d1190233d6a.png)
