### PR TITLE
Fix youtube not working on non debian distros (libssl problem)

### DIFF
--- a/appimage-amd64.yaml
+++ b/appimage-amd64.yaml
@@ -78,15 +78,19 @@ AppDir:
       - mime-support
       - libpam-modules
       - libssl1.1
+      - libllvm11
 
   files:
     exclude:
-      - usr/lib/x86_64-linux-gnu/gconv
-      - usr/share/man
-      - usr/share/doc/*/README.*
-      - usr/share/doc/*/changelog.*
-      - usr/share/doc/*/NEWS.*
-      - usr/share/doc/*/TODO.*
+      - /usr/lib/x86_64-linux-gnu/gconv
+      - /usr/share/man
+      - /usr/share/doc/*/README.*
+      - /usr/share/doc/*/changelog.*
+      - /usr/share/doc/*/NEWS.*
+      - /usr/share/doc/*/TODO.*
+      - /usr/share/wallpapers
+      - /usr/share/locale
+      - /usr/share/perl
   after_bundle:
     # workaround libcrypt.so.2 binary still name as libcrypt.so.1 in debian systems
     - ln -s /usr/lib/libcrypt.so.2 $APPDIR/usr/lib/libcrypt.so.1

--- a/appimage-amd64.yaml
+++ b/appimage-amd64.yaml
@@ -77,6 +77,7 @@ AppDir:
       - sensible-utils
       - mime-support
       - libpam-modules
+      - libssl1.1
 
   files:
     exclude:


### PR DESCRIPTION
Exclude `libssl1.1` from appimage to fix youtube not working on non debian/gentoo based distros (certificate path problem).

Excluding will make appimage use libssl present in the distro, solving the problem, also reducing the size.

@azubieta  any problem with this approach? it's safe to assume libssl is present in every distro.